### PR TITLE
Performance improvements (especially for multi threaded usage) 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,56 +26,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,7 +165,7 @@ name = "symbol_table"
 version = "0.3.0"
 dependencies = [
  "ahash",
- "crossbeam",
+ "crossbeam-utils",
  "hashbrown",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +215,7 @@ name = "symbol_table"
 version = "0.3.0"
 dependencies = [
  "ahash",
+ "crossbeam",
  "hashbrown",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,10 @@ default = []
 global = []
 
 [dependencies]
-ahash = {version = "0.7.6", default-features = false}
+ahash = { version = "0.7.6", default-features = false }
 hashbrown = "0.12"
-serde = {version = "1", optional = true, features = ["derive"]}
+serde = { version = "1", optional = true, features = ["derive"] }
+crossbeam = "0.8.4"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ global = []
 ahash = { version = "0.7.6", default-features = false }
 hashbrown = "0.12"
 serde = { version = "1", optional = true, features = ["derive"] }
-crossbeam = "0.8.4"
+crossbeam-utils = "0.8.4"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/global.rs
+++ b/src/global.rs
@@ -4,6 +4,33 @@ use std::mem::MaybeUninit;
 use std::str::FromStr;
 use std::sync::Once;
 
+#[cfg(feature = "global")]
+/// Macro for creating symbols from &'static str. Useful for commonly used symbols known at compile time.
+/// This is faster then GlobalSymbol::from(s) by avoiding mutex contention.
+///
+/// # Examples
+///
+/// ```
+/// use symbol_table::static_symbol;
+/// use symbol_table::GlobalSymbol;
+///
+/// let hello = static_symbol!("hello");
+/// assert_eq!(hello, GlobalSymbol::from("hello"));
+///
+/// // The same symbol is returned on subsequent calls
+/// let hello2 = static_symbol!("hello");
+/// assert_eq!(hello, hello2);
+/// ```
+#[macro_export]
+macro_rules! static_symbol {
+    ($s:literal) => {{
+        use std::cell::OnceCell;
+        static SYMBOL: OnceCell<GlobalSymbol> = OnceCell::new();
+
+        SYMBOL.get_or_init(|| GlobalSymbol::from($s))
+    }};
+}
+
 /// A interned string in the global symbol table.
 ///
 /// This requires the `global` feature on the crate.

--- a/src/global.rs
+++ b/src/global.rs
@@ -24,10 +24,10 @@ use std::sync::Once;
 #[macro_export]
 macro_rules! static_symbol {
     ($s:literal) => {{
-        use std::cell::OnceCell;
-        static SYMBOL: OnceCell<GlobalSymbol> = OnceCell::new();
+        use std::sync::OnceLock;
+        static SYMBOL: OnceLock<GlobalSymbol> = OnceLock::new();
 
-        SYMBOL.get_or_init(|| GlobalSymbol::from($s))
+        *SYMBOL.get_or_init(|| GlobalSymbol::from($s))
     }};
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use std::{
     num::NonZeroU32,
 };
 
+use crossbeam::utils::CachePadded;
 use hashbrown::hash_map::{HashMap, RawEntryMut};
 use std::sync::Mutex;
 
@@ -45,7 +46,7 @@ pub const DEFAULT_N_SHARDS: usize = 16;
 /// for lower contention when accessing concurrently.
 pub struct SymbolTable<const N: usize = DEFAULT_N_SHARDS, S = DeterministicHashBuilder> {
     build_hasher: S,
-    shards: [Mutex<Shard>; N],
+    shards: [CachePadded<Mutex<Shard>>; N],
 }
 
 impl<const N: usize, S> SymbolTable<N, S> {
@@ -70,7 +71,7 @@ impl<const N: usize, S: BuildHasher> SymbolTable<N, S> {
         // println!("SHARD_BITS = {}", Self::SHARD_BITS);
         // println!("MAX_IDX = {}", Self::MAX_IDX);
         let mut shards = Vec::with_capacity(N);
-        shards.resize_with(N, Default::default);
+        shards.resize_with(N, || CachePadded::new(Mutex::new(Shard::default())));
         Self {
             build_hasher,
             shards: shards.try_into().unwrap_or_else(|_| panic!()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use std::{
     num::NonZeroU32,
 };
 
-use crossbeam::utils::CachePadded;
+use crossbeam_utils::CachePadded;
 use hashbrown::hash_map::{HashMap, RawEntryMut};
 use std::sync::Mutex;
 


### PR DESCRIPTION
 ## False Sharing
The default `[Mutex<Shard>; 16]` is about 1-2 cache lines in total on most platforms. This means we don't get the full improvement over a single mutex in practice due to false sharing. 

We can fix this by introducing padding so that shards are cache line aligned. 

## Static Symbols
The easiest way to use common symbols known at compile time is`GlobalSymbol::from("i64")`. This issue can be seen in EggLog where `eval_lit` effectively locks & unlocks the same mutex in a loop. 

`static_symbol!` makes it easier to use the once pattern to avoid this issue.  

